### PR TITLE
Merge read summary json properly

### DIFF
--- a/bin/extract_kraken_reads.py
+++ b/bin/extract_kraken_reads.py
@@ -315,12 +315,12 @@ def fastq_iterator(
 
     for taxon, records in out_records_1.items():
         if fastq_2:
-            with open(f"{prefix}.{taxon}_1.{filetype}", "w") as f:
+            with open(f"{taxon}_1.{filetype}", "w") as f:
                 for record in records:
                     name, seq, qual = record
                     f.write(f"@{name}\n{seq}\n+\n{qual}\n")
         else:
-            with open(f"{prefix}.{taxon}.{filetype}", "w") as f:
+            with open(f"{taxon}.{filetype}", "w") as f:
                 for record in records:
                     name, seq, qual = record
                     f.write(f"@{name}\n{seq}\n+\n{qual}\n")
@@ -347,7 +347,7 @@ def fastq_iterator(
                         out_records_2[taxon].append(record)
 
         for taxon, records in out_records_2.items():
-            with open(f"{prefix}.{taxon}_2.{filetype}", "w") as f:
+            with open(f"{taxon}_2.{filetype}", "w") as f:
                 for record in records:
                     name, seq, qual = record
                     f.write(f"@{name}\n{seq}\n+\n{qual}\n")
@@ -393,8 +393,8 @@ def extract_taxa(
                     "taxon": taxon,
                     "tax_level": report_entries[taxon]["rank"],
                     "filenames": [
-                        "%s.%s_1.%s" % (prefix, taxon, filetype),
-                        "%s.%s_2.%s" % (prefix, taxon, filetype),
+                        "%s_1.%s" % (taxon, filetype),
+                        "%s_2.%s" % (taxon, filetype),
                     ],
                     "qc_metrics": {
                         "num_reads": out_counts[taxon],
@@ -410,7 +410,7 @@ def extract_taxa(
                     "taxon": taxon,
                     "tax_level": report_entries[taxon]["rank"],
                     "filenames": [
-                        "%s.%s.%s" % (prefix, taxon, filetype),
+                        "%s.%s" % (taxon, filetype),
                     ],
                     "qc_metrics": {
                         "num_reads": out_counts[taxon],

--- a/conf/params.config
+++ b/conf/params.config
@@ -152,7 +152,7 @@ params {
       ]
       agent = null
       container = "biowilko/scylla"
-      container_version = "1.1.0"
+      container_version = "1.1.1"
     }
 }
 

--- a/dockerfiles/scylla/environment.yml
+++ b/dockerfiles/scylla/environment.yml
@@ -15,3 +15,4 @@ dependencies:
   - fastp
   - tabix
   - mako
+  - jq

--- a/modules/extract_taxa.nf
+++ b/modules/extract_taxa.nf
@@ -58,7 +58,7 @@ process extract_paired_reads {
             --rank ${params.extract_rank} \
             --min_percent ${min_percent}
 
-        PATTERN=(*.fastq)
+        PATTERN=(*.f*q)
         if [ ! -f \${PATTERN[0]} ]; then
             echo "Found no output files - maybe there weren't any for this sample"
             exit 3

--- a/modules/extract_taxa.nf
+++ b/modules/extract_taxa.nf
@@ -41,7 +41,7 @@ process extract_paired_reads {
         tuple val(unique_id), path(fastq1), path(fastq2), path(kraken_assignments), path(kreport), val(min_reads), val(min_percent)
         path taxonomy_dir
     output:
-        tuple val(unique_id), path("reads.*.f*"), emit: reads
+        tuple val(unique_id), path("*.fastq"), emit: reads
         path "${kreport}_summary.json", emit: summary
     script:
         """
@@ -58,7 +58,7 @@ process extract_paired_reads {
             --rank ${params.extract_rank} \
             --min_percent ${min_percent}
 
-        PATTERN=(reads.*.f*)
+        PATTERN=(*.fastq)
         if [ ! -f \${PATTERN[0]} ]; then
             echo "Found no output files - maybe there weren't any for this sample"
             exit 3
@@ -80,7 +80,7 @@ process extract_reads {
         tuple val(unique_id), path(fastq), path(kraken_assignments), path(kreport), val(min_reads), val(min_percent)
         path taxonomy_dir
     output:
-        tuple val(unique_id), path("reads.*.f*"), emit: reads
+        tuple val(unique_id), path("*.fastq"), emit: reads
         path "${kreport}_summary.json", emit: summary
     script:
         """
@@ -96,7 +96,7 @@ process extract_reads {
             --rank ${params.extract_rank} \
             --min_percent ${min_percent}
 
-        PATTERN=(reads.*.f*)
+        PATTERN=(*.fastq)
         if [ ! -f \${PATTERN[0]} ]; then
             echo "Found no output files - maybe there weren't any for this sample"
             exit 3
@@ -119,7 +119,7 @@ process bgzip_extracted_taxa {
           tuple val(unique_id), path("reads.*.f*.gz")
       script:
           """
-          for f in \$(ls reads.*.f*)
+          for f in \$(ls *.fastq)
             do
             bgzip --threads $task.cpus \$f
             done

--- a/modules/extract_taxa.nf
+++ b/modules/extract_taxa.nf
@@ -80,7 +80,7 @@ process extract_reads {
         tuple val(unique_id), path(fastq), path(kraken_assignments), path(kreport), val(min_reads), val(min_percent)
         path taxonomy_dir
     output:
-        tuple val(unique_id), path("*.fastq"), emit: reads
+        tuple val(unique_id), path("*.f*q"), emit: reads
         path "${kreport}_summary.json", emit: summary
     script:
         """
@@ -96,7 +96,7 @@ process extract_reads {
             --rank ${params.extract_rank} \
             --min_percent ${min_percent}
 
-        PATTERN=(*.fastq)
+        PATTERN=(*.f*q)
         if [ ! -f \${PATTERN[0]} ]; then
             echo "Found no output files - maybe there weren't any for this sample"
             exit 3
@@ -116,10 +116,10 @@ process bgzip_extracted_taxa {
       input:
           tuple val(unique_id), path(read_files)
       output:
-          tuple val(unique_id), path("reads.*.f*.gz")
+          tuple val(unique_id), path("*.f*q.gz")
       script:
           """
-          for f in \$(ls *.fastq)
+          for f in \$(ls *.f*q)
             do
             bgzip --threads $task.cpus \$f
             done

--- a/modules/extract_taxa.nf
+++ b/modules/extract_taxa.nf
@@ -130,7 +130,7 @@ process merge_read_summary {
 
     label 'process_single'
 
-    publishDir path: "${params.outdir}/${unique_id}/reads_by_taxa", pattern: "reads_summary_combined.json", mode: 'copy'
+    publishDir path: "${params.outdir}/${params.unique_id}/reads_by_taxa", pattern: "reads_summary_combined.json", mode: 'copy'
 
     container "${params.wf.container}:${params.wf.container_version}"
 


### PR DESCRIPTION
Merge summary json using jq, fairly uncontroversial change

One potentially controversial change is to only utilise the prefix param in `extract_kraken_reads.py` for the summary file (to avoid naming collisions) and to output binned taxa to files using the pattern `{tax_id}.fastq` or `{tax_id}_{1,2}.fastq` rather than `{prefix}_{tax_id}.fastq` so the prefix can be the split kraken report filename. Happy to discuss a different solution if this breaks something important.